### PR TITLE
Adding requirements file for installing Python library dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+stable-baselines3
+serial
+serial.tools
+pyserial
+scipy


### PR DESCRIPTION
Much easier to install dependencies with pip install -r requirements.txt rather than fish through package dependency requirements.